### PR TITLE
fix burger menu keyboard support

### DIFF
--- a/src/js/init-aria-expanded.js
+++ b/src/js/init-aria-expanded.js
@@ -4,32 +4,51 @@ module.exports = function initAriaExpanded(el) {
 	 * this is needed to ensure that the page
 	 * is accesable without javascript
 	 */
-	el.setAttribute('aria-expanded', false);
+	el.setAttribute("aria-expanded", false);
 
 	/**
 	 * toggle aria expanded attribute for current target element
 	 */
-	el.addEventListener('click', function () {
-		if (el.getAttribute('aria-expanded') === 'false') {
-			el.setAttribute('aria-expanded', true);
+	el.addEventListener("click", toggleAriaExpanded);
+	function toggleAriaExpanded() {
+		if (el.getAttribute("aria-expanded") === "false") {
+			el.setAttribute("aria-expanded", true);
 		} else {
-			el.setAttribute('aria-expanded', false);
+			el.setAttribute("aria-expanded", false);
 		}
-	});
+	}
 
 	/**
-	 * if keycode is equal to escape key
-	 * set checkbox state false
-	 * set aria expanded false
-	 * and set focus to trigger element
+	 * control aria expanded attribute and checkbox checked attribute with enter and escape key
 	 */
-	document.addEventListener('keydown', function (event) {
-		if (event.keyCode === 27) {
-			const elCheckbox = el.previousSibling;
+	function additionalKeys() {
+		const elCheckbox = el.previousSibling;
 
-			triggerCheckbox.checked = false;
-			el.setAttribute('aria-expanded', 'false');
-			el.focus();
-		}
-	});
-}
+		/**
+		 * if keycode is equal to enter key
+		 * toggle checkbox
+		 * toggle aria expanded
+		 */
+		elCheckbox.addEventListener("keydown", function (event) {
+			if (event.keyCode === 13) {
+				elCheckbox.checked = !elCheckbox.checked;
+				toggleAriaExpanded();
+			}
+		});
+
+		/**
+		 * if keycode is equal to escape key
+		 * set checkbox state false
+		 * set aria expanded false
+		 * and set focus to trigger element
+		 */
+		document.addEventListener("keydown", function (event) {
+			if (event.keyCode === 27) {
+				elCheckbox.checked = false;
+				el.setAttribute("aria-expanded", "false");
+				el.focus();
+			}
+		});
+	}
+	additionalKeys();
+};


### PR DESCRIPTION
Hi 👋

I feel the need to prepend that this is my first ever PR! Yay!

I was browsing the site and noticed that the burger menu keyboard accessibility could be improved. Initially, I tried to open it with the `Enter` key, which wasn't working. The `Spacebar` key does the trick, but isn't very intuitive, in my opinion, because you'd expect a button behaviour.

My first approach was then to just replace it with a semantically correct `<button>` element, which would've solved the keyboard support issue instantly, but then quickly understood why you weren't doing that in the first place. Your purely CSS solution to the burger menu, a hidden checkbox, was really cool to see. Who did that? That's amazing!

I then noticed you were using some JavaScript after all, to help with accessibility, but it's still impressive 😅I also saw, that you were trying to make the `escape` key exit the menu, which actually doesn't work and throws an error in the console:
`app.js:1088 Uncaught ReferenceError: triggerCheckbox is not defined
    at HTMLDocument.<anonymous> (app.js:1088)`
so I came up with these changes to make the escape button work, and also to add the enter key support.

In my opinion this slightly enhances the intuitiveness of browsing the site with a keyboard.

Let me know what you think!

Best, David ❤️