### PR TITLE
fix: google maps link of Frankfurt office

### DIFF
--- a/src/templates/module_07_locations/template.html
+++ b/src/templates/module_07_locations/template.html
@@ -136,7 +136,7 @@ name: Locations
 			data-marker="Mayfarthstraße 15"
 			className="map map-frankfurt"
 			rel="noopener noreferrer"
-			href="https://www.google.de/maps/place/SinnerSchrader/@50.1136884,8.7149786,17z/data=!3m1!4b1!4m5!3m4!1s0x47bd0bfa1014b789:0xe4bed44fc61a4e8f!8m2!3d50.113685!4d8.7171673"
+			href="https://www.google.de/maps/place/SinnerSchrader/@50.110078,8.7083032,17z/data=!3m1!4b1!4m5!3m4!1s0x47bd0bfa1014b789:0xe4bed44fc61a4e8f!8m2!3d50.110078!4d8.710492"
 			target="_blank"
 			>
 			<ResponsiveImage


### PR DESCRIPTION
The place was updated in Google Maps, but the encoded coordinates pointed to the old office location